### PR TITLE
Adjust macOS app for Xcode10.0, Swift4.2 and AudioKit4.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: objective-c
-osx_image: xcode9.3
+osx_image: xcode10
 env:
 - LANG=en_US.UTF-8 LC_CTYPE=en_US.UTF-8
 before_install:

--- a/iOS/Podfile.lock
+++ b/iOS/Podfile.lock
@@ -1,18 +1,20 @@
 PODS:
-  - AudioKit (4.3.1):
-    - AudioKit/UI (= 4.3.1)
-  - AudioKit/UI (4.3.1)
+  - AudioKit (4.4.0):
+    - AudioKit/Core (= 4.4.0)
+    - AudioKit/UI (= 4.4.0)
+  - AudioKit/Core (4.4.0)
+  - AudioKit/UI (4.4.0)
 
 DEPENDENCIES:
   - AudioKit
 
 SPEC REPOS:
-  https://github.com/AudioKit/Specs.git:
+  https://github.com/cocoapods/specs.git:
     - AudioKit
 
 SPEC CHECKSUMS:
-  AudioKit: cc046831314339331b7dbbebc62a01b5d20eda2b
+  AudioKit: 79c2b23cd00beb656938aa0b81b614391f17eaa3
 
 PODFILE CHECKSUM: b120b52a86155117fb0313a71b9c7ab59aeed676
 
-COCOAPODS: 1.5.3
+COCOAPODS: 1.6.0.beta.1

--- a/iOS/SamplerDemo.xcodeproj/project.pbxproj
+++ b/iOS/SamplerDemo.xcodeproj/project.pbxproj
@@ -108,6 +108,7 @@
 				3404A7F920509A3600A2C9E4 /* Sources */,
 				3404A7FA20509A3600A2C9E4 /* Frameworks */,
 				3404A7FB20509A3600A2C9E4 /* Resources */,
+				1F96F6A72C9EE85FFA5F3E2A /* [CP] Embed Pods Frameworks */,
 			);
 			buildRules = (
 			);
@@ -130,6 +131,7 @@
 				TargetAttributes = {
 					3404A7FC20509A3600A2C9E4 = {
 						CreatedOnToolsVersion = 9.2;
+						LastSwiftMigration = 1000;
 						ProvisioningStyle = Automatic;
 					};
 				};
@@ -183,6 +185,28 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
+			showEnvVarsInLog = 0;
+		};
+		1F96F6A72C9EE85FFA5F3E2A /* [CP] Embed Pods Frameworks */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-SamplerDemo/Pods-SamplerDemo-frameworks.sh",
+				"${PODS_ROOT}/AudioKit/iOS/AudioKitUI.framework",
+			);
+			name = "[CP] Embed Pods Frameworks";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/AudioKitUI.framework",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-SamplerDemo/Pods-SamplerDemo-frameworks.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
 /* End PBXShellScriptBuildPhase section */
@@ -346,7 +370,7 @@
 				OTHER_LDFLAGS = "$(inherited)";
 				PRODUCT_BUNDLE_IDENTIFIER = io.audiokit.SamplerDemo;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_VERSION = 4.0;
+				SWIFT_VERSION = 4.2;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Debug;
@@ -363,7 +387,7 @@
 				OTHER_LDFLAGS = "$(inherited)";
 				PRODUCT_BUNDLE_IDENTIFIER = io.audiokit.SamplerDemo;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_VERSION = 4.0;
+				SWIFT_VERSION = 4.2;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Release;

--- a/iOS/SamplerDemo/AppDelegate.swift
+++ b/iOS/SamplerDemo/AppDelegate.swift
@@ -13,7 +13,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
     var window: UIWindow?
 
-    func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplicationLaunchOptionsKey: Any]?) -> Bool {
+    func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
         // Override point for customization after application launch.
         return true
     }

--- a/macOS/Podfile.lock
+++ b/macOS/Podfile.lock
@@ -1,18 +1,20 @@
 PODS:
-  - AudioKit (4.3.1):
-    - AudioKit/UI (= 4.3.1)
-  - AudioKit/UI (4.3.1)
+  - AudioKit (4.4.0):
+    - AudioKit/Core (= 4.4.0)
+    - AudioKit/UI (= 4.4.0)
+  - AudioKit/Core (4.4.0)
+  - AudioKit/UI (4.4.0)
 
 DEPENDENCIES:
   - AudioKit
 
 SPEC REPOS:
-  https://github.com/AudioKit/Specs.git:
+  https://github.com/cocoapods/specs.git:
     - AudioKit
 
 SPEC CHECKSUMS:
-  AudioKit: cc046831314339331b7dbbebc62a01b5d20eda2b
+  AudioKit: 79c2b23cd00beb656938aa0b81b614391f17eaa3
 
 PODFILE CHECKSUM: eb24da0873eb6f9e294dd2a4ed08fc19d9a155b0
 
-COCOAPODS: 1.5.3
+COCOAPODS: 1.6.0.beta.1

--- a/macOS/SamplerDemo.xcodeproj/project.pbxproj
+++ b/macOS/SamplerDemo.xcodeproj/project.pbxproj
@@ -107,6 +107,7 @@
 				3404A8202050AA3500A2C9E4 /* Sources */,
 				3404A8212050AA3500A2C9E4 /* Frameworks */,
 				3404A8222050AA3500A2C9E4 /* Resources */,
+				34F462FE452314CC37C15810 /* [CP] Embed Pods Frameworks */,
 			);
 			buildRules = (
 			);
@@ -129,6 +130,7 @@
 				TargetAttributes = {
 					3404A8232050AA3500A2C9E4 = {
 						CreatedOnToolsVersion = 9.2;
+						LastSwiftMigration = 1000;
 						ProvisioningStyle = Automatic;
 						SystemCapabilities = {
 							com.apple.Sandbox = {
@@ -170,6 +172,28 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
+		34F462FE452314CC37C15810 /* [CP] Embed Pods Frameworks */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-SamplerDemo/Pods-SamplerDemo-frameworks.sh",
+				"${PODS_ROOT}/AudioKit/macOS/AudioKitUI.framework",
+			);
+			name = "[CP] Embed Pods Frameworks";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/AudioKitUI.framework",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-SamplerDemo/Pods-SamplerDemo-frameworks.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
 		E27D4137B35CEA46CCF8C0B4 /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
@@ -343,7 +367,7 @@
 				OTHER_LDFLAGS = "$(inherited)";
 				PRODUCT_BUNDLE_IDENTIFIER = io.audiokit.SamplerDemo;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_VERSION = 4.0;
+				SWIFT_VERSION = 4.2;
 			};
 			name = Debug;
 		};
@@ -362,7 +386,7 @@
 				OTHER_LDFLAGS = "$(inherited)";
 				PRODUCT_BUNDLE_IDENTIFIER = io.audiokit.SamplerDemo;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_VERSION = 4.0;
+				SWIFT_VERSION = 4.2;
 			};
 			name = Release;
 		};

--- a/macOS/SamplerDemo/ViewController.swift
+++ b/macOS/SamplerDemo/ViewController.swift
@@ -80,7 +80,7 @@ class ViewController: NSViewController, NSWindowDelegate {
         filterEnableCheckbox.state = sampler.filterEnable ? .on : .off
         filterCutoffSlider.intValue = Int32(sampler.filterCutoff)
         filterCutoffReadout.doubleValue = sampler.filterCutoff
-        filterEgStrengthReadout.doubleValue = sampler.filterEgStrength
+        filterEgStrengthReadout.doubleValue = sampler.filterStrength
         filterResonanceSlider.doubleValue = sampler.filterResonance
         filterResonanceReadout.doubleValue = sampler.filterResonance
 
@@ -162,7 +162,7 @@ class ViewController: NSViewController, NSWindowDelegate {
 
     @IBAction func onFilterEgStrengthSliderChange(_ sender: NSSlider) {
         filterEgStrengthReadout.doubleValue = sender.doubleValue
-        sampler.filterEgStrength = sender.doubleValue
+        sampler.filterStrength = sender.doubleValue
     }
 
     @IBAction func onFilterResonanceSlider(_ sender: NSSlider) {


### PR DESCRIPTION
NOTE: Requires at least CocoaPods 1.6.0.beta1. With v1.5.3 it will show
an error "Command PhaseScriptExecution failed..."

NOTE: Switches the spec repo to https://github.com/cocoapods/specs.git: